### PR TITLE
[TTAR-25] Daum Postcode Service 추가 및 주소 입력 컴포넌트 분리, 상세 주소 입력칸 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "13.5.4",
         "next-auth": "^4.24.5",
         "react": "^18",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18",
         "react-redux": "^8.1.3",
         "sass": "^1.68.0",
@@ -3642,6 +3643,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "13.5.4",
     "next-auth": "^4.24.5",
     "react": "^18",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18",
     "react-redux": "^8.1.3",
     "sass": "^1.68.0",

--- a/src/app/order/deliveryAdd/page.tsx
+++ b/src/app/order/deliveryAdd/page.tsx
@@ -13,6 +13,7 @@ const DeliveryAdd = () => {
   const [alias, setAlias] = useState('');
   const [receiver, setReceiver] = useState('');
   const [address, setAddress] = useState('');
+  const [addressDetail, setAddressDetail] = useState('');
   const [phone, setPhone] = useState('');
 
   const inputDataArr = [
@@ -34,6 +35,12 @@ const DeliveryAdd = () => {
       title: '주소',
       placeholder: '우편 번호를 입력해주세요.',
       type: 'search',
+    },
+    {
+      data: addressDetail,
+      setData: setAddressDetail,
+      title: '상세 주소',
+      placeholder: '상세 주소를 입력해주세요.',
     },
     {
       data: phone,

--- a/src/components/InputText/InputText.scss
+++ b/src/components/InputText/InputText.scss
@@ -17,23 +17,3 @@
   outline: none;
   padding: 0 0 9px 10px;
 }
-
-.search_wrapper {
-  @include flex_container(space-between);
-  width: 100%;
-  height: 31px;
-  border-top: 0;
-  border-left: 0;
-  border-right: 0;
-  border-bottom: 1px solid #d9d9d9;
-  padding: 0 10px 9px 0;
-  & > input {
-    outline: none;
-    border: 0;
-    padding: 0;
-    flex: 1;
-    &::placeholder {
-      color: $mainColor;
-    }
-  }
-}

--- a/src/components/InputText/InputText.tsx
+++ b/src/components/InputText/InputText.tsx
@@ -1,7 +1,13 @@
 'use client';
-import Image from 'next/image';
 import './InputText.scss';
+
+import Image from 'next/image';
 import search from '../../../public/search-mainColor.svg';
+
+import DaumPostcodeEmbed, { useDaumPostcodePopup } from 'react-daum-postcode';
+import { useState } from 'react';
+import { postcodeScriptUrl } from 'react-daum-postcode/lib/loadPostcode';
+import SearchAddress from '../SearchAddress/SearchAddress';
 
 type Props = {
   data: string;
@@ -22,15 +28,11 @@ const InputText = ({
     <>
       <span className="label">{title}</span>
       {type === 'search' ? (
-        <div className="search_wrapper">
-          <input
-            value={data}
-            placeholder={placeholder}
-            onChange={(e) => setData(e.target.value)}
-            readOnly
-          />
-          <Image src={search} alt="search" />
-        </div>
+        <SearchAddress
+          data={data}
+          setData={setData}
+          placeholder={placeholder}
+        />
       ) : (
         <input
           value={data}

--- a/src/components/SearchAddress/SearchAddress.scss
+++ b/src/components/SearchAddress/SearchAddress.scss
@@ -1,0 +1,24 @@
+@import '../../app/globals.scss';
+
+.search_wrapper {
+  @include flex_container(space-between);
+  width: 100%;
+  height: 31px;
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 1px solid #d9d9d9;
+  padding: 0 0 9px 10px;
+  & > input {
+    outline: none;
+    border: 0;
+    padding: 0;
+    flex: 1;
+    &::placeholder {
+      color: $mainColor;
+    }
+  }
+  .searchButton {
+    cursor: pointer;
+  }
+}

--- a/src/components/SearchAddress/SearchAddress.tsx
+++ b/src/components/SearchAddress/SearchAddress.tsx
@@ -1,0 +1,35 @@
+'use client';
+import './SearchAddress.scss';
+
+import Image from 'next/image';
+import search from '../../../public/search-mainColor.svg';
+
+import { useDaumPostcodePopup } from 'react-daum-postcode';
+import { postcodeScriptUrl } from 'react-daum-postcode/lib/loadPostcode';
+
+const SearchAddress = ({ data, placeholder, setData }) => {
+  const open = useDaumPostcodePopup(postcodeScriptUrl);
+
+  const handleComplete = (data) => {
+    const { address, zonecode } = data;
+    setData(`${address} ${zonecode}`);
+  };
+
+  function searchAddress() {
+    open({ onComplete: handleComplete });
+  }
+
+  return (
+    <div className="search_wrapper">
+      <input value={data} placeholder={placeholder} readOnly />
+      <Image
+        src={search}
+        alt="search"
+        className="searchButton"
+        onClick={searchAddress}
+      />
+    </div>
+  );
+};
+
+export default SearchAddress;


### PR DESCRIPTION
## 📖 개요

## 💻 작업사항

- Daum postcode Service 추가 (npm install 해주셔야 합니다!)
- 주소 입력 인풋 컴포넌트 분리
- 상세 주소 입력창 추가 (Figma에는 없지만 상세 주소가 있어야할 것 같아서 임의로 추가했습니다)

## 💡 작성한 이슈 외에 작업한 사항

-

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
